### PR TITLE
Use default colors if cookie is invalid

### DIFF
--- a/scripting/custom_status_hud.sp
+++ b/scripting/custom_status_hud.sp
@@ -113,9 +113,7 @@ void GetClientHudTextParams(int client, float &x, float &y, int &color) {
 	
 	GetClientCookie(client, g_PrefHudColor, buffer, sizeof(buffer));
 	
-	if (buffer[0]) {
-		StringToIntEx(buffer, color, 16);
-	} else {
+	if (!buffer[0] || !StringToIntEx(buffer, color, 16)) {
 		color = 0xFFFF00FF;
 	}
 }


### PR DESCRIPTION
Ran into a problem where the statushud_color was overwritten with a different clientpref, so the resulting string equaled "0" and made the text invisible. Might fix #2 ?